### PR TITLE
Don't put the bibIds in the delete field

### DIFF
--- a/src/main/java/com/recap/updater/deletions/DeleteInfoProcessor.java
+++ b/src/main/java/com/recap/updater/deletions/DeleteInfoProcessor.java
@@ -108,7 +108,6 @@ public class DeleteInfoProcessor implements Processor {
               List<Map<String, Object>> items = (List) theBib.get(ITEMS);
 
               for (Map<String, Object> item : items) {
-                item.put(BIB_IDS, Arrays.asList());
                 deletedItems.add(transformToDeleted(item, Constants.ITEM,
                     (String) theBib.get(OWNING_INSTITUTION_CODE)));
               }
@@ -151,7 +150,6 @@ public class DeleteInfoProcessor implements Processor {
       Map<String, Object> itemRecord = new HashMap<>();
       itemRecord.put(OWNING_INSTITUTION_ITEM_ID, itemId);
       itemRecord.put(OWNING_INSTITUTION_BIB_ID, owningInstitutionBibId);
-      itemRecord.put(BIB_IDS, Arrays.asList());
       deletedItems.add(transformToDeleted(itemRecord, Constants.ITEM, owningInstitutionCode));
     }
   }
@@ -248,7 +246,7 @@ public class DeleteInfoProcessor implements Processor {
       deletedRecord.put("deletedDate", deleteDateFormat.format(new Date()));
       deletedRecord.put("deleted", true);
       deletedRecord.put("fixedFields", new HashMap<>());
-      deletedRecord.put("varFields", new ArrayList<>());
+      deletedRecord.put("varFields", Arrays.asList());
 
       if (bibOrItem == Constants.BIB) {
         deletedRecord.put("id", record.get(OWNING_INSTITUTION_BIB_ID));

--- a/src/main/java/com/recap/updater/deletions/DeleteInfoProcessor.java
+++ b/src/main/java/com/recap/updater/deletions/DeleteInfoProcessor.java
@@ -108,7 +108,7 @@ public class DeleteInfoProcessor implements Processor {
               List<Map<String, Object>> items = (List) theBib.get(ITEMS);
 
               for (Map<String, Object> item : items) {
-                item.put(BIB_IDS, Arrays.asList(theBib.get(OWNING_INSTITUTION_BIB_ID)));
+                item.put(BIB_IDS, Arrays.asList());
                 deletedItems.add(transformToDeleted(item, Constants.ITEM,
                     (String) theBib.get(OWNING_INSTITUTION_CODE)));
               }
@@ -151,7 +151,7 @@ public class DeleteInfoProcessor implements Processor {
       Map<String, Object> itemRecord = new HashMap<>();
       itemRecord.put(OWNING_INSTITUTION_ITEM_ID, itemId);
       itemRecord.put(OWNING_INSTITUTION_BIB_ID, owningInstitutionBibId);
-      itemRecord.put(BIB_IDS, Arrays.asList(owningInstitutionBibId));
+      itemRecord.put(BIB_IDS, Arrays.asList());
       deletedItems.add(transformToDeleted(itemRecord, Constants.ITEM, owningInstitutionCode));
     }
   }
@@ -258,7 +258,7 @@ public class DeleteInfoProcessor implements Processor {
         logger.info("deleting the individual item: " + owningInstitution + "-"
             + record.get(OWNING_INSTITUTION_ITEM_ID));
         deletedRecord.put("id", record.get(OWNING_INSTITUTION_ITEM_ID));
-        deletedRecord.put(BIB_IDS, record.get(BIB_IDS));
+        deletedRecord.put(BIB_IDS, Arrays.asList());
       }
 
       return new ObjectMapper().writeValueAsString(deletedRecord);


### PR DESCRIPTION
The [pcdm-store-updater](https://github.com/NYPL-discovery/pcdm-store-updater) will add the bibIds if delete == true.
Now the onus is off the multiple apps that send "delete-y"
messages. Services like this one and the bib and item
retreievers.

For more details see:

* https://jira.nypl.org/browse/SRCH-319
* https://github.com/NYPL-discovery/pcdm-store-updater/pull/54



Stephen